### PR TITLE
fix: layout name must include extension to work with hot reloading

### DIFF
--- a/src/content/pages/pages.json
+++ b/src/content/pages/pages.json
@@ -1,5 +1,5 @@
 {
-  "layout": "base",
+  "layout": "base.njk",
   "permalink": "/{{ title | slugify }}/",
   "templateEngineOverride": "njk, md"
 }


### PR DESCRIPTION
While it worked with the whole build it wasn't working with hot reloading. While eleventyConfig.addLayoutAlias() might work too, this seems to be a cleaner and simpler solution.

This is AI generated explanation of the problem. 
Not sure if true but adding extension 100 % solved it.

> When the Eleventy server is restarted, it performs a complete rebuild of all content, handling all template resolution from scratch. During hot reloading, it tries to be more efficient by only rebuilding what it thinks has changed.
> 
> Here's why this matters in your specific case:
> 
> 1. **Initial Build (Server Start)**: When you started the server, Eleventy did a full build and somehow managed to find your base layout through its fallback mechanisms or initial template resolution, despite the missing extension in `pages.json`.
> 
> 2. **Incremental Builds (Hot Reload)**: When you made changes to `base.njk`, the incremental build process looked specifically for what files depend on `base.njk` - but your pages were configured to depend on `base` (without extension), creating a mismatch.
> 
> 3. **Template Dependency Tracking**: Eleventy's hot reload system tracks dependencies between files to determine what needs rebuilding. If the dependency path is incorrect (due to the missing extension), it won't properly track changes.
> 
> This is a classic case of development vs. build environment differences. The extension-less template reference might have worked in some contexts but failed in others, which is why being explicit with extensions is a best practice.
> 
> The reason a full server restart fixed it is that the full build process is more thorough in resolving templates than the incremental hot reload process, which relies heavily on previously established file relationships.